### PR TITLE
TK4195 - forcer l'affichage de la ref produit sur le PDF commande fou…

### DIFF
--- a/admin/grapefruit_setup.php
+++ b/admin/grapefruit_setup.php
@@ -205,6 +205,14 @@ echo ajax_constantonoff('GRAPEFRUIT_SUPPLIER_CONTACT_SHIP_ADDRESS');
 print '</form>';
 print '</td></tr>';
 
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans("set_GRAPEFRUIT_FORCE_VAR_HIDEREF_ON_SUPPLIER_ORDER").'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+echo ajax_constantonoff('GRAPEFRUIT_FORCE_VAR_HIDEREF_ON_SUPPLIER_ORDER');
+print '</td></tr>';
+
 print '<tr class="liste_titre">';
 print '<td>'.$langs->trans("CustomerOrder").'</td>'."\n";
 print '<td align="center" width="20">&nbsp;</td>';

--- a/class/actions_grapefruit.class.php
+++ b/class/actions_grapefruit.class.php
@@ -61,29 +61,18 @@ class ActionsGrapeFruit
 	 */
 	function doActions($parameters, &$object, &$action, $hookmanager)
 	{
-		/*$error = 0; // Error counter
-		$myvalue = 'test'; // A result value
-
-		print_r($parameters);
-		echo "action: " . $action;
-		print_r($object);
-
-		if (in_array('somecontext', explode(':', $parameters['context'])))
+		global $conf;
+		
+		if ($parameters['currentcontext'] == 'ordersuppliercard')
 		{
-		  // do something only for the context 'somecontext'
+			if ($action == 'builddoc' && !empty($conf->global->GRAPEFRUIT_FORCE_VAR_HIDEREF_ON_SUPPLIER_ORDER))
+			{
+				global $hideref;
+				$hideref = 0;
+			}
 		}
-
-		if (! $error)
-		{
-			$this->results = array('myreturn' => $myvalue);
-			$this->resprints = 'A text to show';
-			return 0; // or return 1 to replace standard code
-		}
-		else
-		{
-			$this->errors[] = 'Error message';
-			return -1;
-		}*/
+		
+		return 0;
 	}
 
 	function formObjectOptions($parameters, &$object, &$action, $hookmanager)

--- a/core/modules/modGrapeFruit.class.php
+++ b/core/modules/modGrapeFruit.class.php
@@ -89,7 +89,7 @@ class modGrapeFruit extends DolibarrModules
 		//                        );
 		$this->module_parts = array(
 			'triggers' => 1
-			,'hooks' => array('propalcard', 'suppliercard', 'pdfgeneration','invoicecard')
+			,'hooks' => array('propalcard', 'suppliercard', 'pdfgeneration','invoicecard','ordersuppliercard')
 		);
 
 		// Data directories to create when module is enabled.

--- a/langs/fr_FR/grapefruit.lang
+++ b/langs/fr_FR/grapefruit.lang
@@ -28,3 +28,4 @@ DefaultWarehouseRequired=Entrepôt requis pour la création de l'expédition
 set_GRAPEFRUIT_DATEEND_NEEDED=Date de fin de projet requise à la création
 set_GRAPEFRUIT_SHIPPING_CREATE_FROM_ORDER_WHERE_BILL_PAID_WAREHOUSE=Entrepôt pour la création de l'expédition
 set_GRAPEFRUIT_SEND_BILL_BY_MAIL_ON_VALIDATE_MODEL=Modèle à utiliser
+set_GRAPEFRUIT_FORCE_VAR_HIDEREF_ON_SUPPLIER_ORDER=Forcer l'affichage de la référence produit sur le PDF d'une commande fournisseur même avec l'utilisation de MAIN_GENERATE_DOCUMENTS_HIDE_REF


### PR DESCRIPTION
…rnisseur

Si la conf MAIN_GENERATE_DOCUMENTS_HIDE_REF est active, alors le nouveau param du module permet de forcer l'affichage de la ref produit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_grapefruit/3)
<!-- Reviewable:end -->
