### PR TITLE
New : allow to bypass formconfirm for some actions

### DIFF
--- a/admin/grapefruit_setup.php
+++ b/admin/grapefruit_setup.php
@@ -538,6 +538,24 @@ echo ajax_constantonoff('MAIN_ADD_EVENT_ON_ELEMENT_CARD');
 print '</form>';
 print '</td></tr>';
 
+print '<tr class="liste_titre">';
+print '<td>' . $langs->trans("Global") . '</td>' . "\n";
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="100">' . $langs->trans("Value") . '</td>' . "\n";
+
+$var = ! $var;
+print '<tr ' . $bc[$var] . '>';
+print '<td>' . $langs->trans("set_GRAPEFRUIT_BYPASS_CONFIRM_ACTIONS") . '</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '">';
+print '<input type="hidden" name="token" value="' . $_SESSION['newtoken'] . '">';
+print '<input type="hidden" name="action" value="set_GRAPEFRUIT_BYPASS_CONFIRM_ACTIONS">';
+print '<input type="text" name="GRAPEFRUIT_BYPASS_CONFIRM_ACTIONS" value="' . $conf->global->GRAPEFRUIT_BYPASS_CONFIRM_ACTIONS . '" style="width:300px;max-width:100%;" />';
+print '<input type="submit" class="button" value="' . $langs->trans("Modify") . '">';
+print '</form>';
+print '</td></tr>';
+
 print '</table>';
 
 llxFooter();

--- a/class/actions_grapefruit.class.php
+++ b/class/actions_grapefruit.class.php
@@ -63,12 +63,26 @@ class ActionsGrapeFruit
 	{
 		global $conf;
 		
+		$TContext = explode(':', $parameters['context']);
+		
 		if ($parameters['currentcontext'] == 'ordersuppliercard')
 		{
 			if ($action == 'builddoc' && !empty($conf->global->GRAPEFRUIT_FORCE_VAR_HIDEREF_ON_SUPPLIER_ORDER))
 			{
 				global $hideref;
 				$hideref = 0;
+			}
+		}
+		
+		// Bypass des confirmation
+		if (in_array('globalcard', $TContext))
+		{
+			$actionList = explode(',', $conf->global->GRAPEFRUIT_BYPASS_CONFIRM_ACTIONS);
+			if (in_array($action, $actionList))
+			{
+				global $confirm;
+				$confirm = 'yes';
+				$action = 'confirm_'.$action;
 			}
 		}
 		

--- a/core/modules/modGrapeFruit.class.php
+++ b/core/modules/modGrapeFruit.class.php
@@ -89,7 +89,7 @@ class modGrapeFruit extends DolibarrModules
 		//                        );
 		$this->module_parts = array(
 			'triggers' => 1
-			,'hooks' => array('contactcard', 'propalcard', 'suppliercard', 'pdfgeneration','invoicecard','ordersuppliercard', 'thirdpartycard', 'fullcalendardao')
+			,'hooks' => array('contactcard', 'propalcard', 'suppliercard', 'pdfgeneration','invoicecard','ordersuppliercard', 'thirdpartycard', 'fullcalendardao','globalcard')
 			,'models' => 1
 		);
 

--- a/langs/fr_FR/grapefruit.lang
+++ b/langs/fr_FR/grapefruit.lang
@@ -49,3 +49,6 @@ set_GRAPEFRUIT_ALLOW_CREATE_ORDER_AND_BILL_ON_UNSIGNED_PROPAL=Autoriser la créa
 
 # Models
 DocumentModelDorade=Modèle d'expédition chiffré
+
+# Global
+set_GRAPEFRUIT_BYPASS_CONFIRM_ACTIONS=Ne pas demander de confirmation sur les actions


### PR DESCRIPTION
Option to avoid formconfirm, for example on validate or reopen actions. Action list must be defined in conf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_grapefruit/12)
<!-- Reviewable:end -->
