### PR TITLE
add missing return (error on dolibarr.log)

### DIFF
--- a/class/actions_grapefruit.class.php
+++ b/class/actions_grapefruit.class.php
@@ -620,7 +620,7 @@ class ActionsGrapeFruit
 			}
 
 		}
-
+		return 0;
 	}
 
 
@@ -724,6 +724,7 @@ class ActionsGrapeFruit
 				}
 			} // Fin order / order_supplier
 		}
+		return 0;
 	}
 
 	function addOptionCalendarEvents($parameters, &$object, &$action, $hookmanager)

--- a/class/actions_grapefruit.class.php
+++ b/class/actions_grapefruit.class.php
@@ -184,7 +184,7 @@ class ActionsGrapeFruit
 			</script>
 			<?php
 		}
-
+		return 0;
 	}
 
 	function formObjectOptions($parameters, &$object, &$action, $hookmanager)


### PR DESCRIPTION
For errors like

```
  Bug into hook beforePDFCreation of module class ActionsGrapeFruit. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints
 Bug into hook formEditProductOptions of module class ActionsGrapeFruit. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints
 Bug into hook pdf_getLinkedObjects of module class ActionsGrapeFruit. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints
```
